### PR TITLE
Interpolate latPlan to 100hz (#546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stock Additions - [2021-12-31](/SA_RELEASES.md) (0.8.13)
+# Stock Additions - [2022-01-01](/SA_RELEASES.md) (0.8.13)
 
 Stock Additions is a fork of openpilot designed to be minimal in design while boasting various feature additions and behavior improvements over stock. I have a 2017 Toyota Corolla with comma pedal, so most of my changes are designed to improve the longitudinal performance.
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,5 +1,7 @@
 Stock Additions 0.8.13
 ===
+## - 2022-01-01
+ * Improve lateral performance by interpolating lateral plan to 100hz (from 20hz)
 ## - 2021-12-31, 5:00pm MST Notes
  * A few controls improvements related to right after engaging:
    * Car no longer brakes for a second after engaging at low speeds if there's no lead

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -96,14 +96,14 @@ def initialize_v_cruise(v_ego, buttonEvents, v_cruise_last):
   return int(round(clip(v_ego * CV.MS_TO_KPH, V_CRUISE_ENABLE_MIN, V_CRUISE_MAX)))
 
 
-def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates):
+def get_lag_adjusted_curvature(CP, v_ego, psis, curvatures, curvature_rates, delay_offset):
   if len(psis) != CONTROL_N:
     psis = [0.0 for i in range(CONTROL_N)]
     curvatures = [0.0 for i in range(CONTROL_N)]
     curvature_rates = [0.0 for i in range(CONTROL_N)]
 
   # TODO this needs more thought, use .2s extra for now to estimate other delays
-  delay = CP.steerActuatorDelay + .2
+  delay = CP.steerActuatorDelay + .2 + delay_offset
   current_curvature = curvatures[0]
   psi = interp(delay, T_IDXS[:CONTROL_N], psis)
   desired_curvature_rate = curvature_rates[0]


### PR DESCRIPTION
* interpolate lateral plan to 100hz

comment

* Revert "Follow plan sooner after engaging (#545)"

This reverts commit d86d8ea476060a17e61af8448bfa60030d7a0a0e.

* run without constraint for a frame

* try to debug

* Revert "try to debug"

This reverts commit 5a25f2f571665b6b5552fb35c7a29c766c99706a.

* Revert "run without constraint for a frame"

This reverts commit ff36d2521fcd34d539f0ef5448de04c809565db5.

* Revert "Revert "Follow plan sooner after engaging (#545)""

This reverts commit 073b75a3667892a33409e301dafff9e1da41fa20.

* add release notes

* add release notes

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
